### PR TITLE
fix(#17): enemy boundary uses live scale, HUD fixed to camera

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## On every new conversation
+
+**Always read [`CONVERSATION_MEMORY.md`](./CONVERSATION_MEMORY.md) first.** It stores key decisions, preferences, and context from past sessions. After each session where something noteworthy happened (design decision, preference expressed, feature shipped), append a new dated entry to that file.
+
+## Commands
+
+```bash
+npm run dev       # Start Vite dev server with hot reload
+npm run build     # Production build
+npm run preview   # Preview production build locally
+npm run lint      # Run ESLint
+```
+
+There are no automated tests beyond the CI build check (`.github/workflows/node.js.yml` runs `npm install` + `npm run build` on Node 18/20/22).
+
+## Architecture
+
+GlitchWars is a browser-based retro arcade game. The stack is **React + React Router** for the shell/landing page and **Phaser 3** (Arcade physics) for the actual game, embedded in a React component.
+
+### Navigation flow
+
+```
+/ (landing)  →  /select-gender  →  /select-hero  →  /game
+```
+
+Hero/gender selection is stored in React state and passed into the Phaser game instance via `Game.jsx`, which manages Phaser lifecycle (create/destroy on mount/unmount) and debounced canvas resizing (16:9 aspect ratio, 320×240 min, 1920×1080 max).
+
+### Phaser game (`src/game/`)
+
+Three scenes run in sequence: **BootScene** (asset preload) → **MenuScene** → **PlayScene** (main loop).
+
+**Managers** own distinct subsystems and are instantiated by PlayScene:
+- `EnemyManager` — spawn rate, movement, health bars, wave-scaled stats
+- `LevelManager` — score → level → wave progression; difficulty timer fires every 10s to tighten spawn intervals
+- `InputManager` — Arrow keys + WASD
+- `CollisionManager` — registers Arcade physics overlaps between player, enemies, and weapons
+
+**Entities** are Phaser GameObjects extended with game logic:
+- `Player` — movement, invulnerability window after damage, stat scaling per wave
+- `Enemy` — health/speed driven by `(wave × multiplier) + (level × multiplier)`, destruction VFX on death
+
+**UI** (`src/game/ui/`) — in-game HUD (HealthBar, ScoreDisplay, GameOverScreen) built with Phaser text/graphics, not React.
+
+**Utils** (`src/game/utils/`) — `EffectsHelper` for level-up/wave/screen-flash effects; `ScreenUtils` for responsive UI positioning.
+
+### Scoring & difficulty
+
+- Score threshold per level: `200 × 1.5^(level-1)` (exponential)
+- Every 5 levels = new wave; waves buff enemy health, speed, and damage
+- Difficulty timer fires every 10s independent of wave progression
+
+### Styling
+
+Tailwind CSS 4 with a retro pixel theme: "Press Start 2P" font, black/green/cyan palette, scanline overlay. Custom animations (`glitch`, `flicker`, `wiggle`, `bounceGlow`) are defined in `tailwind.config.js`.

--- a/CONVERSATION_MEMORY.md
+++ b/CONVERSATION_MEMORY.md
@@ -1,0 +1,37 @@
+# Conversation Memory
+
+This file stores key decisions, patterns, and context from past conversations with Claude Code.
+It should be read at the start of every new session to maintain continuity.
+
+---
+
+## Session: 2026-04-26
+
+### Project initialized
+- Created `CLAUDE.md` with architecture overview and dev commands.
+- GlitchWars is a **Phaser 3 + React** retro arcade game built with Vite.
+- No unit tests exist — CI only runs `npm run build`.
+
+### Developer preferences
+- User (MouryA6) wants Claude to maintain persistent memory across conversations via this file.
+- Review this file at the start of every new conversation or whenever `CLAUDE.md` is read.
+
+### Recent features merged (from git log)
+- **PR #47** — Level-up particle effects (`LevelUpEffects` branch)
+- **PR #46** — Issue #33 fix (merged into main)
+
+---
+
+## Session: 2026-04-30
+
+### Project audit completed
+- Conversation agent did a full project status review — ~30-45h estimated to demo-ready.
+- 10 new GitHub issues created (#50–#59) for unlogged bugs, dead content, and feature gaps.
+
+### Issue #17 fixed (branch: claude-edits)
+Three root causes identified and fixed:
+1. **Enemy boundary bug** (`EnemyManager.spawnEnemy` + `isEnemyOffscreen`): was using stale `scene.config.width/height` (initial values). Fixed to use `scene.scale.width/height` so enemies correctly track the live canvas size after resize.
+2. **HUD shifts on damage** (`ScoreDisplay`, `HealthBar`): all HUD elements were missing `setScrollFactor(0)`. Camera shake on damage (every hit) caused the entire HUD to visually drift. Fixed.
+3. **GameOver screen not camera-fixed** (`GameOverScreen`): container missing `setScrollFactor(0)`. Fixed.
+
+<!-- Append new sessions below this line in the same format -->

--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -123,33 +123,29 @@ export class EnemyManager {
       let x, y;
       let spriteKey;
       
-      const config = this.scene.config || {
-        width: this.scene.game.config.width,
-        height: this.scene.game.config.height
-      };
-      
+      const sceneWidth = this.scene.scale.width;
+      const sceneHeight = this.scene.scale.height;
+
       switch(side) {
         case 0: // top
-          x = Phaser.Math.Between(0, config.width);
+          x = Phaser.Math.Between(0, sceneWidth);
           y = -buffer;
-          // Compare with player's x position to determine facing
           spriteKey = (x < this.scene.player.sprite.x) ? this.enemyRightKey : this.enemyLeftKey;
           break;
         case 1: // right
-          x = config.width + buffer;
-          y = Phaser.Math.Between(0, config.height);
-          spriteKey = this.enemyLeftKey; // Always face left when spawning from right
+          x = sceneWidth + buffer;
+          y = Phaser.Math.Between(0, sceneHeight);
+          spriteKey = this.enemyLeftKey;
           break;
         case 2: // bottom
-          x = Phaser.Math.Between(0, config.width);
-          y = config.height + buffer;
-          // Compare with player's x position to determine facing
+          x = Phaser.Math.Between(0, sceneWidth);
+          y = sceneHeight + buffer;
           spriteKey = (x < this.scene.player.sprite.x) ? this.enemyRightKey : this.enemyLeftKey;
           break;
         case 3: // left
           x = -buffer;
-          y = Phaser.Math.Between(0, config.height);
-          spriteKey = this.enemyRightKey; // Always face right when spawning from left
+          y = Phaser.Math.Between(0, sceneHeight);
+          spriteKey = this.enemyRightKey;
           break;
       }
       
@@ -219,17 +215,12 @@ export class EnemyManager {
    * @returns {boolean} - True if the enemy is off-screen
    */
   isEnemyOffscreen(enemySprite) {
-    const config = this.scene.config || {
-      width: this.scene.game.config.width,
-      height: this.scene.game.config.height
-    };
-    
     const buffer = 50;
     const bounds = {
       left: -buffer,
-      right: config.width + buffer,
+      right: this.scene.scale.width + buffer,
       top: -buffer,
-      bottom: config.height + buffer
+      bottom: this.scene.scale.height + buffer
     };
     
     return (

--- a/src/game/ui/GameOverScreen.js
+++ b/src/game/ui/GameOverScreen.js
@@ -37,6 +37,7 @@ export class GameOverScreen {
     
     // Create centered container for game over elements
     this.container = this.scene.add.container(0, 0);
+    this.container.setScrollFactor(0);
     
     // Black overlay
     this.overlay = this.scene.add.rectangle(

--- a/src/game/ui/HealthBar.js
+++ b/src/game/ui/HealthBar.js
@@ -43,24 +43,25 @@ export class HealthBar {
   createHealthBar() {
     // Health bar background (black)
     this.barBackground = this.scene.add.rectangle(
-      this.x, 
-      this.y, 
-      this.width, 
-      this.height, 
+      this.x,
+      this.y,
+      this.width,
+      this.height,
       0x000000
-    ).setOrigin(0, 0);
-    
+    ).setOrigin(0, 0).setScrollFactor(0);
+
     // Health bar fill (starts green)
     this.barFill = this.scene.add.rectangle(
-      this.x + 2, // +2 padding from left
-      this.y + 2, // +2 padding from top
-      this.width - 4, // -4 for left and right padding
-      this.height - 4, // -4 for top and bottom padding
+      this.x + 2,
+      this.y + 2,
+      this.width - 4,
+      this.height - 4,
       0x00ff00
-    ).setOrigin(0, 0);
-    
+    ).setOrigin(0, 0).setScrollFactor(0);
+
     // Create a separate border using graphics (more reliable than stroke style)
     this.barBorder = this.scene.add.graphics();
+    this.barBorder.setScrollFactor(0);
     this.drawBorder();
     
     // Store the initial width for scaling
@@ -69,27 +70,27 @@ export class HealthBar {
     // Add health text label if needed
     if (this.label) {
       this.healthLabel = this.scene.add.text(
-        this.x, 
-        this.y - this.fontSize - 5, 
-        this.label, 
+        this.x,
+        this.y - this.fontSize - 5,
+        this.label,
         {
           fontSize: `${this.fontSize}px`,
           fill: '#ffffff'
         }
-      );
+      ).setScrollFactor(0);
     }
-    
+
     // Add health value text if needed
     if (this.showText) {
       this.healthText = this.scene.add.text(
-        this.x + this.width + 10, 
-        this.y + 2, 
-        `${Math.ceil(this.currentHealth)}/${this.maxHealth}`, 
+        this.x + this.width + 10,
+        this.y + 2,
+        `${Math.ceil(this.currentHealth)}/${this.maxHealth}`,
         {
           fontSize: `${this.fontSize}px`,
           fill: '#ffffff'
         }
-      );
+      ).setScrollFactor(0);
     }
   }
   

--- a/src/game/ui/ScoreDisplay.js
+++ b/src/game/ui/ScoreDisplay.js
@@ -37,47 +37,47 @@ export class ScoreDisplay {
   createUI() {
     // Score text
     this.scoreText = this.scene.add.text(
-      this.x, 
-      this.y, 
-      `Score: ${this.score}`, 
-      { 
-        fontSize: `${this.fontSize}px`, 
+      this.x,
+      this.y,
+      `Score: ${this.score}`,
+      {
+        fontSize: `${this.fontSize}px`,
         fill: this.color
       }
-    );
-    
+    ).setScrollFactor(0);
+
     // Level text
     this.levelText = this.scene.add.text(
-      this.x, 
-      this.y + this.fontSize + this.spacing, 
-      `Level: ${this.level}`, 
+      this.x,
+      this.y + this.fontSize + this.spacing,
+      `Level: ${this.level}`,
       {
         fontSize: `${this.fontSize}px`,
         fill: this.color
       }
-    );
-    
+    ).setScrollFactor(0);
+
     // Wave text
     this.waveText = this.scene.add.text(
-      this.x, 
-      this.y + (this.fontSize + this.spacing) * 2, 
-      `Wave: ${this.wave}`, 
+      this.x,
+      this.y + (this.fontSize + this.spacing) * 2,
+      `Wave: ${this.wave}`,
       {
         fontSize: `${this.fontSize}px`,
         fill: this.color
       }
-    );
-    
+    ).setScrollFactor(0);
+
     // Character info
     this.characterText = this.scene.add.text(
-      this.scene.scale.width - 16, 
-      this.y, 
-      `Hero: ${this.characterName}`, 
+      this.scene.scale.width - 16,
+      this.y,
+      `Hero: ${this.characterName}`,
       {
         fontSize: `${this.fontSize}px`,
         fill: this.color
       }
-    ).setOrigin(1, 0);
+    ).setOrigin(1, 0).setScrollFactor(0);
   }
   
   /**


### PR DESCRIPTION
- EnemyManager.spawnEnemy/isEnemyOffscreen now use scene.scale.width/height instead of stale scene.config dimensions so enemies correctly chase the player at any canvas size after resize
- Added setScrollFactor(0) to all ScoreDisplay and HealthBar elements so camera shake on damage no longer displaces the HUD
- Added setScrollFactor(0) to GameOverScreen container so it stays centred regardless of camera state

Closes #17