### PR TITLE
fix(#51,#52): strip PROD DEBUG logs and add CI test placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests yet\" && exit 0"
   },
   "dependencies": {
     "phaser": "^3.88.2",

--- a/src/game/entities/Player.js
+++ b/src/game/entities/Player.js
@@ -119,23 +119,6 @@ export class Player {
         this.sprite.body.offset.x = 0;
       }
       
-      // Debug movement if velocity changed
-      if (Math.abs(this.sprite.body.velocity.x) > 0 || Math.abs(this.sprite.body.velocity.y) > 0) {
-        // Periodically log player position (once per second)
-        const now = Date.now();
-        if (!this._lastPositionLog || now - this._lastPositionLog > 1000) {
-          console.debug('[PROD DEBUG] Player position:', {
-            x: this.sprite.x,
-            y: this.sprite.y,
-            velocity: {
-              x: this.sprite.body.velocity.x,
-              y: this.sprite.body.velocity.y
-            }
-          });
-          this._lastPositionLog = now;
-        }
-      }
-      
       return;
     }
     
@@ -143,22 +126,15 @@ export class Player {
     // Get input handlers from the scene
     const { cursors, wasd } = this.scene;
     if (!cursors && !wasd) {
-      console.debug('[PROD DEBUG] Player: Input handlers not found in scene');
       return;
     }
-    
-    // Debug input state
+
     const inputState = {
       left: wasd?.left?.isDown || cursors?.left?.isDown,
       right: wasd?.right?.isDown || cursors?.right?.isDown,
       up: wasd?.up?.isDown || cursors?.up?.isDown,
       down: wasd?.down?.isDown || cursors?.down?.isDown,
     };
-    
-    // Only log when inputs change to avoid console spam
-    if (this._lastInputState && JSON.stringify(this._lastInputState) !== JSON.stringify(inputState)) {
-      console.debug('[PROD DEBUG] Player input:', inputState);
-    }
     this._lastInputState = {...inputState};
     
     // Horizontal movement (prioritize WASD then arrow keys)
@@ -191,19 +167,6 @@ export class Player {
       this.sprite.body.setVelocityY(this.speed);
     }
     
-    // Periodically log player position (once per second)
-    const now = Date.now();
-    if (!this._lastPositionLog || now - this._lastPositionLog > 1000) {
-      console.debug('[PROD DEBUG] Player position:', {
-        x: this.sprite.x,
-        y: this.sprite.y,
-        velocity: {
-          x: this.sprite.body.velocity.x,
-          y: this.sprite.body.velocity.y
-        }
-      });
-      this._lastPositionLog = now;
-    }
   }
   
   /**

--- a/src/game/managers/CollisionManager.js
+++ b/src/game/managers/CollisionManager.js
@@ -41,8 +41,6 @@ export class CollisionManager {
       return this;
     }
     
-    console.debug('[PROD DEBUG] CollisionManager: Setting up collision detection');
-    
     // Set up physics collision between player and enemies
     this.setupPlayerEnemyCollision();
     
@@ -70,7 +68,6 @@ export class CollisionManager {
       this
     );
     
-    console.debug('[PROD DEBUG] CollisionManager: Player-enemy collision detection active');
   }
   
   /**

--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -37,20 +37,16 @@ export class EnemyManager {
     
     if (player) {
       const playerTarget = player.sprite || player;
-      
-      console.debug('[PROD DEBUG] Setting up player-enemy collision. Player type:', 
-        player.sprite ? 'Player class' : 'Direct sprite',
-        'Target object:', playerTarget);
-      
+
       // Add collision detection between player and enemies
       this.scene.physics.add.collider(
-        playerTarget, 
-        this.enemies, 
-        this.handlePlayerEnemyCollision, 
-        null, 
+        playerTarget,
+        this.enemies,
+        this.handlePlayerEnemyCollision,
+        null,
         this
       );
-      
+
       // Add overlap detection as a backup in case collider fails
       this.scene.physics.add.overlap(
         playerTarget,
@@ -59,8 +55,6 @@ export class EnemyManager {
         null,
         this
       );
-    } else {
-      console.error('[PROD DEBUG] No player found when setting up enemy collisions');
     }
   }
   

--- a/src/game/managers/InputManager.js
+++ b/src/game/managers/InputManager.js
@@ -42,8 +42,6 @@ export class InputManager {
     this.keySpace = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
     this.keyEsc = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     
-    // Debug logging of key mappings
-    console.debug('[PROD DEBUG] Input Manager: Input controls setup complete');
   }
   
   /**

--- a/src/game/scenes/BootScene.js
+++ b/src/game/scenes/BootScene.js
@@ -7,11 +7,6 @@ export class BootScene extends Phaser.Scene {
   }
 
   preload() {
-    console.debug('[PROD DEBUG] BootScene preload started');
-    console.debug('[PROD DEBUG] Running in environment:', window.location.hostname);
-    console.debug('[PROD DEBUG] Base URL:', window.location.origin);
-    console.debug('[PROD DEBUG] Path:', window.location.pathname);
-    
     // Create loading bar
     const width = this.config.width;
     const height = this.config.height;
@@ -40,21 +35,9 @@ export class BootScene extends Phaser.Scene {
     });
 
     this.load.on("complete", () => {
-      console.debug('[PROD DEBUG] All assets loading complete');
       progressBar.destroy();
       progressBox.destroy();
       loadingText.destroy();
-    });
-
-    // Track loading errors
-    this.load.on("loaderror", (fileObj) => {
-      console.error("[PROD DEBUG] Failed to load asset:", fileObj.key, "from URL:", fileObj.url);
-      // We'll handle missing assets in the create method
-    });
-    
-    // Track successfully loaded assets
-    this.load.on("filecomplete", (key) => {
-      console.debug(`[PROD DEBUG] Successfully loaded asset: ${key}`);
     });
 
     // Check if we're in production (based on hostname)
@@ -66,22 +49,15 @@ export class BootScene extends Phaser.Scene {
     
     // For Netlify or similar hosting, we may need to adjust the path
     if (isProduction) {
-      console.debug('[PROD DEBUG] Using production asset paths');
       // Try to determine the base path from the current URL
       const pathParts = window.location.pathname.split('/');
       if (pathParts.length > 2) {
         // If we're in a subdirectory like /game/
         basePath = '.' + basePath;
-        console.debug('[PROD DEBUG] Adjusted base path:', basePath);
       }
     }
 
-    // Load all necessary game assets with debugging
-    console.debug('[PROD DEBUG] Loading background:', `${basePath}/scanline.png`);
     this.load.image("background", `${basePath}/scanline.png`);
-
-    // Debug what directories actually exist
-    console.debug('[PROD DEBUG] Document base URL:', document.baseURI);
 
     // Hero character sprites - Male (with path adjustment)
     this.load.image("wizard_male_1", `${basePath}/WizardsInGameImages/Male/FinalPlayUse/Wizard Male1 60X60.png`);

--- a/src/game/scenes/PlayScene.js
+++ b/src/game/scenes/PlayScene.js
@@ -72,27 +72,17 @@ export class PlayScene extends BaseScene {
       // Get the appropriate hero image path
       let heroImagePath = this.getHeroImagePath();
       
-      console.debug('[PROD DEBUG] Loading game assets');
-      console.debug('[PROD DEBUG] Loading hero image:', heroImagePath);
-      
       this.load.image(this.heroImageKey, heroImagePath);
       this.load.image(this.enemyLeftKey, 'assets/EnemiesInGameImages/FinalPlayUse/Enemy1 40X40LeftFacing.png');
       this.load.image(this.enemyRightKey, 'assets/EnemiesInGameImages/FinalPlayUse/Enemy1 40X40rightFacing.png');
       
-      // Debug asset loading events
-      this.load.on('filecomplete', (key) => {
-        console.debug(`[PROD DEBUG] Asset loaded successfully: ${key}`);
-      });
-      
       this.load.on('loaderror', (fileObj) => {
-        console.error(`[PROD DEBUG] Error loading asset: ${fileObj.key} from ${fileObj.url}`);
         // Create fallback texture if enemy images fail to load
         if (fileObj.key === this.enemyLeftKey || fileObj.key === this.enemyRightKey) {
           this.createFallbackEnemyTextures(fileObj.key);
         }
       });
     } catch (error) {
-      console.error('[PROD DEBUG] Error in preload:', error);
     }
   }
 
@@ -101,8 +91,6 @@ export class PlayScene extends BaseScene {
    */
   create() {
     try {
-      console.debug('[PROD DEBUG] PlayScene.create started');
-      
       // Initialize utility classes
       this.screenUtils = new ScreenUtils(this);
       this.effectsHelper = new EffectsHelper(this);
@@ -148,16 +136,10 @@ export class PlayScene extends BaseScene {
       
       // Setup collisions and enemy spawning
       if (this.player && this.player.sprite && this.enemyManager) {
-        console.debug('[PROD DEBUG] Setting up collisions with player:', this.player);
         this.collisionManager.setup(this.player, this.enemyManager.enemies);
-        
+
         // Start enemy spawning after collisions are set up
         this.enemyManager.startSpawning();
-      } else {
-        console.error('[PROD DEBUG] Cannot setup collisions - player or enemyManager not initialized', {
-          player: this.player,
-          enemyManager: this.enemyManager
-        });
       }
       
       // Start difficulty timer at the end
@@ -169,7 +151,6 @@ export class PlayScene extends BaseScene {
       // Register screen resize event
       this.scale.on('resize', this.onScreenResize, this);
       
-      console.debug('[PROD DEBUG] PlayScene.create completed');
     } catch (error) {
       console.error('Error in PlayScene.create:', error);
       // Create minimal fallback UI to show something
@@ -206,7 +187,6 @@ export class PlayScene extends BaseScene {
       // Clear graphics
       graphics.clear();
       
-      console.debug(`[PROD DEBUG] Created fallback texture for ${key}`);
     } catch (error) {
       console.error(`Error creating fallback texture for ${key}:`, error);
     }


### PR DESCRIPTION
## Summary
- Fixes #51 — all 27+ `[PROD DEBUG]` console.debug calls stripped from `src/` (Player, EnemyManager, CollisionManager, InputManager, BootScene, PlayScene). Zero matches remain in `src/` or the production bundle.
- Fixes #52 — added `"test": "echo \"No tests yet\" && exit 0"` to `package.json` scripts so `npm test` exits 0 and the `node.js.yml` CI workflow no longer fails on every push.

## Test plan
- [ ] `grep -r "PROD DEBUG" src/` → zero results
- [ ] `npm run build` → passes clean; `grep -r "PROD DEBUG" dist/` → zero results
- [ ] `npm test` → exits 0 with "No tests yet"
- [ ] Push to `main` and verify CI green on all three Node versions (18/20/22)
- [ ] Open game in browser with DevTools console — no `[PROD DEBUG]` noise during gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)