### PR TITLE
fix(#69): rebalance enemy health scaling to 2-hit/wave linear curve

### DIFF
--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -8,7 +8,7 @@ export class EnemyManager {
     
     // Enemy properties
     this.enemies = null;
-    this.enemyBaseHealth = scene.enemyBaseHealth || 100;
+    this.enemyBaseHealth = 40; // Wave 1 minimum per the health formula (40 × wave)
     this.enemySpawnRate = scene.enemySpawnRate || 2000; // ms
     this.enemyBaseSpeed = scene.enemyBaseSpeed || 100;
     this.maxEnemies = scene.maxEnemies || 50;
@@ -143,10 +143,10 @@ export class EnemyManager {
           break;
       }
       
-      // Enhanced enemy scaling with wave and level
-      const waveScaling = this.wave * 8;
-      const levelScaling = this.level * 3;
-      const maxHealth = this.enemyBaseHealth + waveScaling + levelScaling;
+      // Health formula: Wave 1 = 40 HP (2 Archer hits), scales linearly per wave
+      const HEALTH_PER_WAVE = 40;
+      const LEVEL_HEALTH_STEP = 2;
+      const maxHealth = (HEALTH_PER_WAVE * this.wave) + (LEVEL_HEALTH_STEP * (this.level - 1));
       
       // Enhanced enemy properties scaling
       const speedScaling = 1 + (this.wave * 0.1) + (this.level * 0.05);
@@ -486,7 +486,7 @@ export class EnemyManager {
     this.wave = wave;
     
     // Update enemy properties based on difficulty
-    this.enemyBaseHealth = 100 + (wave * 8) + (level * 3);
+    // enemyBaseHealth is NOT updated here — health is computed fresh in spawnEnemy to avoid double-scaling
     this.enemyBaseSpeed = Math.min(200, 100 + (wave * 5) + (level * 2));
   }
   

--- a/src/game/managers/LevelManager.js
+++ b/src/game/managers/LevelManager.js
@@ -104,7 +104,10 @@ export class LevelManager {
     // Increase wave after certain levels
     if (this.level % 5 === 0) {
       this.wave++;
-      
+
+      // Immediately sync EnemyManager so spawn health reflects the new wave without waiting for the 10s difficulty timer
+      this.scene.enemyManager?.updateDifficulty(this.level, this.wave);
+
       // Notify wave change callbacks
       this.notifyWaveChangeCallbacks();
       


### PR DESCRIPTION
## Summary

Fixes #69 — enemy health was overtuned at game start (6 Archer hits to kill on Wave 1 instead of the intended 2).

- Replace the broken health formula (`enemyBaseHealth + wave*8 + level*3` = 111 HP at Wave 1) with a wave-anchored linear curve: `(40 × wave) + (2 × (level - 1))` → 40 HP at Wave 1 = exactly 2 Archer hits
- Remove the `enemyBaseHealth` mutation from `updateDifficulty` that caused double-scaling every 10s, inflating health geometrically over time
- Sync `EnemyManager.wave` immediately on wave-up in `LevelManager.levelUp` instead of waiting up to 10s for the difficulty timer, closing the window where post-wave enemies spawned with the wrong health
- Fix constructor fallback from stale `100` to `40` (Wave 1 minimum) so the contact-damage fallback path is consistent with the new formula

## Hit counts by wave (Archer = 20 dmg/shot)

| Wave | Level | maxHP | Archer hits |
|------|-------|-------|-------------|
| 1 | 1 | 40 | 2 |
| 1 | 3 | 44 | 3 |
| 2 | 5 | 88 | 5 |
| 3 | 10 | 138 | 7 |

## Test plan

- [ ] Wave 1 enemy dies in exactly 2 Archer shots
- [ ] Wave 2 enemy (after Level 5) dies in ~4–5 Archer shots
- [ ] No health jump visible after the 10s difficulty tick fires
- [ ] Enemy health immediately reflects new wave on wave transition (no lag)
- [ ] Contact damage still feels punishing (now ~4 HP/tick vs old ~11 HP/tick — intentional)

## Related

- Follow-up tech debt filed as #70 (`LevelManager.getDifficultySettings()` returns stale `enemyBaseHealth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)