### PR TITLE
fix(#70): remove stale enemyBaseHealth from LevelManager

### DIFF
--- a/src/game/managers/LevelManager.js
+++ b/src/game/managers/LevelManager.js
@@ -31,7 +31,6 @@ export class LevelManager {
     // Difficulty settings
     this.enemySpawnRate = config.enemySpawnRate || 2000;
     this.enemyBaseSpeed = config.enemyBaseSpeed || 100;
-    this.enemyBaseHealth = config.enemyBaseHealth || 100;
     this.difficultyIncreaseInterval = config.difficultyIncreaseInterval || 10000;
     
     // Register callbacks
@@ -222,7 +221,7 @@ export class LevelManager {
       wave: this.wave,
       enemySpawnRate: this.enemySpawnRate,
       enemyBaseSpeed: this.enemyBaseSpeed,
-      enemyBaseHealth: this.enemyBaseHealth,
+
       enemyContactDamage: this.enemyContactDamage
     };
   }


### PR DESCRIPTION
## Summary

Fixes #70 — `LevelManager.getDifficultySettings()` was advertising `enemyBaseHealth: 100` at all times, a stale holdover from before the #69 health formula fix.

- Remove `this.enemyBaseHealth` property from the `LevelManager` constructor
- Remove `enemyBaseHealth` key from `getDifficultySettings()` return object

`EnemyManager.spawnEnemy` is the sole source of truth for enemy health since #69. `LevelManager` never updated this field during gameplay, so it was permanently misleading to any consumer of `getDifficultySettings()`.

## Test plan

- [ ] Repo-wide grep confirms no remaining call sites read `getDifficultySettings().enemyBaseHealth` ✅ (verified before merge)
- [ ] `npm run build` passes ✅
- [ ] No regression in enemy health values — `LevelManager` removal is cosmetic, `EnemyManager` health formula is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)