### PR TITLE
feat(#73): wave completes only when all wave enemies are defeated

### DIFF
--- a/src/game/managers/CollisionManager.js
+++ b/src/game/managers/CollisionManager.js
@@ -157,9 +157,13 @@ export class CollisionManager {
       const basePoints = enemy.points || 10;
       this.scene.levelManager.addScore(basePoints);
     }
-    
-    // Destroy the enemy sprite
-    enemy.destroy();
+
+    // Route through EnemyManager so the wave kill counter is incremented
+    if (this.scene.enemyManager) {
+      this.scene.enemyManager.destroyEnemy(enemy);
+    } else {
+      enemy.destroy();
+    }
   }
   
   /**

--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -5,22 +5,32 @@ import { Enemy } from '../entities/Enemy';
 export class EnemyManager {
   constructor(scene) {
     this.scene = scene;
-    
+
     // Enemy properties
     this.enemies = null;
     this.enemyBaseHealth = 40; // Wave 1 minimum per the health formula (40 × wave)
     this.enemySpawnRate = scene.enemySpawnRate || 2000; // ms
     this.enemyBaseSpeed = scene.enemyBaseSpeed || 100;
     this.maxEnemies = scene.maxEnemies || 50;
-    
+
     // Game level properties for scaling
     this.level = scene.level || 1;
     this.wave = scene.wave || 1;
-    
+
+    // Wave lifecycle state
+    this.wavePhase = 'SPAWNING'; // SPAWNING | DRAINING | COMPLETE
+    this.enemiesPerWave = 10 + (2 * this.wave);
+    this.enemiesSpawnedThisWave = 0;
+    this.enemiesKilledThisWave = 0;
+    this.onWaveCompleteCallback = null;
+
+    // Prevents onWaveComplete from firing during scene teardown
+    this.active = true;
+
     // Sprite keys
     this.enemyLeftKey = 'enemyLeft';
     this.enemyRightKey = 'enemyRight';
-    
+
     // Setup enemy group
     this.setupEnemies();
   }
@@ -61,19 +71,27 @@ export class EnemyManager {
   /**
    * Start spawning enemies at a specified rate
    */
-  startSpawning() {
-    // Clear any existing timer
+  startWave(wave) {
+    this.wave = wave;
+    this.wavePhase = 'SPAWNING';
+    this.enemiesPerWave = 10 + (2 * this.wave);
+    this.enemiesSpawnedThisWave = 0;
+    this.enemiesKilledThisWave = 0;
+
     if (this.enemySpawnTimer) {
       this.enemySpawnTimer.remove();
     }
-    
-    // Start spawning enemies
+
     this.enemySpawnTimer = this.scene.time.addEvent({
       delay: this.enemySpawnRate,
       callback: this.spawnEnemy,
       callbackScope: this,
       loop: true
     });
+  }
+
+  startSpawning() {
+    this.startWave(this.wave);
   }
   
   /**
@@ -86,6 +104,10 @@ export class EnemyManager {
     }
   }
   
+  onWaveComplete(callback) {
+    this.onWaveCompleteCallback = callback;
+  }
+
   /**
    * Update the spawn rate (typically based on difficulty)
    * @param {number} newRate - New spawn rate in milliseconds
@@ -105,12 +127,22 @@ export class EnemyManager {
   spawnEnemy() {
     try {
       if (!this.enemies || !this.scene.player || !this.scene.player.sprite) return;
-      
+
+      if (this.wavePhase !== 'SPAWNING') return;
+
       // Limit maximum number of enemies for performance
       if (this.enemies.getChildren().length >= this.maxEnemies) {
         return;
       }
-      
+
+      if (this.enemiesSpawnedThisWave >= this.enemiesPerWave) {
+        this.wavePhase = 'DRAINING';
+        this.stopSpawning();
+        return;
+      }
+
+      this.enemiesSpawnedThisWave++;
+
       // Randomly spawn enemies outside the visible area
       const side = Math.floor(Math.random() * 4);
       const buffer = 40;
@@ -394,7 +426,6 @@ export class EnemyManager {
       
       if (enemySprite.currentHealth <= 0) {
         enemySprite.active = false;
-        // Use levelManager to add score instead of calling a non-existent addScore method
         if (this.scene.levelManager) {
           this.scene.levelManager.addScore(enemySprite.value || 10);
         } else {
@@ -417,7 +448,21 @@ export class EnemyManager {
       // Clean up health bars
       if (enemySprite.healthBar) enemySprite.healthBar.destroy();
       if (enemySprite.healthBarBg) enemySprite.healthBarBg.destroy();
-      
+
+      // Count every removal (kill or offscreen) toward wave completion
+      this.enemiesKilledThisWave++;
+      if (
+        this.active &&
+        this.scene.sys.isActive() &&
+        this.wavePhase === 'DRAINING' &&
+        this.enemiesKilledThisWave >= this.enemiesPerWave
+      ) {
+        this.wavePhase = 'COMPLETE';
+        if (typeof this.onWaveCompleteCallback === 'function') {
+          this.onWaveCompleteCallback(this.wave);
+        }
+      }
+
       // Random destruction effect
       const effectType = Phaser.Math.Between(1, 3);
       switch (effectType) {
@@ -502,6 +547,7 @@ export class EnemyManager {
    * Clean up resources before scene shutdown
    */
   destroy() {
+    this.active = false;
     this.stopSpawning();
     this.clearAllEnemies();
   }

--- a/src/game/managers/LevelManager.js
+++ b/src/game/managers/LevelManager.js
@@ -96,39 +96,35 @@ export class LevelManager {
    */
   levelUp() {
     this.level++;
-    
+
     // Notify callbacks
     this.notifyLevelUpCallbacks();
-    
-    // Increase wave after certain levels
-    if (this.level % 5 === 0) {
-      this.wave++;
 
-      // Immediately sync EnemyManager so spawn health reflects the new wave without waiting for the 10s difficulty timer
-      this.scene.enemyManager?.updateDifficulty(this.level, this.wave);
-
-      // Notify wave change callbacks
-      this.notifyWaveChangeCallbacks();
-      
-      // Limited health increase with cap
-      const prevMaxHealth = this.playerMaxHealth;
-      this.playerMaxHealth = Math.min(this.maxHealthCap, this.playerMaxHealth + this.healthIncreaseAmount);
-      
-      // Small heal on wave completion
-      const healAmount = this.playerMaxHealth * 0.2;
-      this.playerCurrentHealth = Math.min(
-        this.playerMaxHealth,
-        this.playerCurrentHealth + healAmount
-      );
-    }
-    
     // Slower player speed increase
     this.playerSpeed = Math.min(300, (this.playerSpeed || 200) + 5);
-    
+
     // Increase enemy spawn rate and damage with each level
     this.enemySpawnRate = Math.max(500, this.enemySpawnRate - 50);
     this.enemyContactDamage = Math.min(20, (this.enemyContactDamage || 5) + 1);
-    
+
+    return this;
+  }
+
+  advanceWave(newWave) {
+    this.wave = newWave;
+
+    this.scene.enemyManager?.updateDifficulty(this.level, this.wave);
+
+    this.playerMaxHealth = Math.min(this.maxHealthCap, this.playerMaxHealth + this.healthIncreaseAmount);
+
+    const healAmount = this.playerMaxHealth * 0.2;
+    this.playerCurrentHealth = Math.min(
+      this.playerMaxHealth,
+      this.playerCurrentHealth + healAmount
+    );
+
+    this.notifyWaveChangeCallbacks();
+
     return this;
   }
   

--- a/src/game/scenes/PlayScene.js
+++ b/src/game/scenes/PlayScene.js
@@ -131,7 +131,7 @@ export class PlayScene extends BaseScene {
         );
 
         // Start enemy spawning after collisions are set up
-        this.enemyManager.startSpawning();
+        this.enemyManager.startWave(1);
       }
       
       // Start difficulty timer at the end
@@ -214,6 +214,12 @@ export class PlayScene extends BaseScene {
       }
     });
     
+    this.enemyManager.onWaveComplete((completedWave) => {
+      const nextWave = completedWave + 1;
+      this.levelManager.advanceWave(nextWave);
+      this.enemyManager.startWave(nextWave);
+    });
+
     this.levelManager.onScoreUpdate((score) => {
       this.scoreDisplay.updateScore(score);
     });


### PR DESCRIPTION
## Summary

Fixes #73 — waves previously advanced purely by score/level threshold with no concept of per-wave enemy budgets. Now a wave only completes once every enemy from that wave is destroyed or escapes off-screen.

- Introduces a 3-phase state machine (`SPAWNING → DRAINING → COMPLETE`) in `EnemyManager`
- Each wave spawns exactly `10 + (2 × wave)` enemies (Wave 1 = 12, Wave 2 = 14, …)
- Spawning halts once the quota is reached; wave advances only when the kill counter meets the quota
- `LevelManager.levelUp()` no longer increments the wave — new `advanceWave(n)` handles it, triggered by `EnemyManager.onWaveComplete`
- `CollisionManager.destroyEnemy` now delegates to `EnemyManager.destroyEnemy` so contact kills are counted toward the wave quota

## Test plan

- [ ] Wave 1 spawns exactly 12 enemies, then stops
- [ ] Wave does not advance while any enemy is still alive
- [ ] After last enemy dies, wave-change visual fires and Wave 2 begins (14 enemies)
- [ ] Off-screen escapes count toward wave completion (no permanent DRAINING stall)
- [ ] Score → level-up still works independently (level display updates per kill)
- [ ] Player heal + max-health bump still apply on wave change
- [ ] Game-over mid-wave produces no spurious wave-complete callbacks (no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)