### PR TITLE
feat(#75): enemy speed ramp and peer separation

### DIFF
--- a/src/game/entities/Enemy.js
+++ b/src/game/entities/Enemy.js
@@ -35,7 +35,8 @@ export class Enemy {
       this.sprite.baseSpeed = this.speed;
       this.sprite.damage = this.damage;
       this.sprite.value = this.value;
-      
+      this.sprite.spawnTime = scene.time.now;
+
       // Create health bar for this enemy
       this.createHealthBar();
     } catch (error) {
@@ -73,7 +74,8 @@ export class Enemy {
       this.sprite.baseSpeed = this.speed;
       this.sprite.damage = this.damage;
       this.sprite.value = this.value;
-      
+      this.sprite.spawnTime = this.scene.time.now;
+
       // Create health bar
       this.createHealthBar();
     } catch (error) {

--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -3,6 +3,11 @@ import Phaser from 'phaser';
 import { Enemy } from '../entities/Enemy';
 
 export class EnemyManager {
+  static RAMP_DURATION_MS = 1500;
+  static RAMP_START_FRACTION = 0.35;
+  static SEPARATION_RADIUS = 60;
+  static SEPARATION_STRENGTH = 0.8;
+
   constructor(scene) {
     this.scene = scene;
 
@@ -293,15 +298,33 @@ export class EnemyManager {
         }
       }
       
-      // Dynamic speed based on distance (faster when further away)
+      // Ramp speed from RAMP_START_FRACTION up to full over RAMP_DURATION_MS
       const baseSpeed = enemySprite.baseSpeed || this.enemyBaseSpeed;
-      const minSpeed = baseSpeed * 0.5;
-      const maxSpeed = baseSpeed * 1.2;
-      const speedFactor = Math.min(1, Math.max(0.5, distance / 300));
-      const speed = minSpeed + (maxSpeed - minSpeed) * speedFactor;
-      
-      // Move towards player
-      this.scene.physics.moveToObject(enemySprite, player, speed);
+      const elapsed = this.scene.time.now - (enemySprite.spawnTime || this.scene.time.now);
+      const rampT = Math.min(1, elapsed / EnemyManager.RAMP_DURATION_MS);
+      const rampMultiplier = EnemyManager.RAMP_START_FRACTION + (1 - EnemyManager.RAMP_START_FRACTION) * rampT;
+      const speed = baseSpeed * rampMultiplier;
+
+      const dx = player.x - enemySprite.x;
+      const dy = player.y - enemySprite.y;
+      const len = Math.sqrt(dx * dx + dy * dy) || 1;
+      let vx = (dx / len) * speed;
+      let vy = (dy / len) * speed;
+
+      this.enemies.getChildren().forEach((other) => {
+        if (other === enemySprite || !other.active) return;
+        const sx = enemySprite.x - other.x;
+        const sy = enemySprite.y - other.y;
+        const dist = Math.sqrt(sx * sx + sy * sy) || 1;
+        if (dist < EnemyManager.SEPARATION_RADIUS) {
+          const push = (EnemyManager.SEPARATION_RADIUS - dist) / EnemyManager.SEPARATION_RADIUS;
+          vx += (sx / dist) * push * EnemyManager.SEPARATION_STRENGTH * speed;
+          vy += (sy / dist) * push * EnemyManager.SEPARATION_STRENGTH * speed;
+        }
+      });
+
+      const finalLen = Math.sqrt(vx * vx + vy * vy) || 1;
+      enemySprite.body.setVelocity((vx / finalLen) * speed, (vy / finalLen) * speed);
     } catch (error) {
       console.error('Error updating enemy movement:', error);
     }


### PR DESCRIPTION
## Summary

Fixes #75 — Wave 3+ enemies spawning at full speed immediately and clustering near the player with degraded movement speed.

**Bug 1 — Immediate full speed on spawn:**
Enemies now ramp from 35% → 100% of their wave-scaled `baseSpeed` over 1500ms using a linear lerp anchored to `sprite.spawnTime`. The aggressive wave multiplier is still applied at spawn time, but felt gradually rather than instantly.

**Bug 2 — Clustering slowdown:**
Removed the old distance-based speed clamp (`speedFactor = Math.min(1, Math.max(0.5, dist/300))`) that caused all nearby enemies to slow simultaneously. Replaced `physics.moveToObject` with manual `body.setVelocity` so a peer separation force can be composed with the seek vector — enemies within 60px push each other apart, preventing the pile-up that caused the perceived speed drop.

## Changes
- `EnemyManager.js` — 4 static tuning constants; `updateEnemyMovement` replaced with ramp + seek + separation + normalize
- `Enemy.js` — `sprite.spawnTime = scene.time.now` added to both normal and fallback constructor paths

## Tuning constants (easy to adjust)
| Constant | Value | Effect |
|---|---|---|
| `RAMP_DURATION_MS` | 1500 | Ramp window in ms |
| `RAMP_START_FRACTION` | 0.35 | Starting speed as % of baseSpeed |
| `SEPARATION_RADIUS` | 60px | Distance at which enemies push apart |
| `SEPARATION_STRENGTH` | 0.8 | Force magnitude (sub-1 keeps seek dominant) |

## Test plan
- [ ] Wave 1 enemy visibly accelerates from spawn over ~1.5s
- [ ] Wave 3+ enemy starts slow and reaches full speed — not instant
- [ ] Multiple enemies no longer stack on a single pixel when chasing the player
- [ ] Enemy still reliably tracks and reaches the player
- [ ] Wave completion, score, and health scaling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)