### PR TITLE
fix: enemy speed constant at 100 px/s across all waves

### DIFF
--- a/src/game/managers/EnemyManager.js
+++ b/src/game/managers/EnemyManager.js
@@ -185,9 +185,7 @@ export class EnemyManager {
       const LEVEL_HEALTH_STEP = 2;
       const maxHealth = (HEALTH_PER_WAVE * this.wave) + (LEVEL_HEALTH_STEP * (this.level - 1));
       
-      // Enhanced enemy properties scaling
-      const speedScaling = 1 + (this.wave * 0.1) + (this.level * 0.05);
-      const baseSpeed = this.enemyBaseSpeed * speedScaling * (0.8 + Math.random() * 0.4);
+      const baseSpeed = this.enemyBaseSpeed;
       const damage = 5 + Math.floor(this.wave * 1.5) + Math.floor(this.level * 0.5);
       const value = 10 + Math.floor(this.wave * 2);
       
@@ -555,7 +553,7 @@ export class EnemyManager {
     
     // Update enemy properties based on difficulty
     // enemyBaseHealth is NOT updated here — health is computed fresh in spawnEnemy to avoid double-scaling
-    this.enemyBaseSpeed = Math.min(200, 100 + (wave * 5) + (level * 2));
+    // enemyBaseSpeed is intentionally not scaled — speed is constant across all waves (100 px/s)
   }
   
   /**


### PR DESCRIPTION
## Summary

Enemies were still feeling fast because wave/level speed scaling was multiplying `enemyBaseSpeed` in two places:

1. `spawnEnemy` — `speedScaling = 1 + (wave*0.1) + (level*0.05)` pushed Wave 3 enemies to 1.3× base, plus a ±20% random jitter on top
2. `updateDifficulty` — mutated `enemyBaseSpeed` upward every 10s (`100 + wave*5 + level*2`)

Both removed. All enemies now spawn at a flat 100 px/s regardless of wave or level.

The spawn ramp-up from #75 (35% → 100% over 1500ms) is preserved — enemies still feel like they gradually close in after appearing, they just never exceed 100 px/s.

## Changes
- `EnemyManager.spawnEnemy` — removed `speedScaling` and random jitter; `baseSpeed = this.enemyBaseSpeed` (always 100)
- `EnemyManager.updateDifficulty` — removed `this.enemyBaseSpeed` mutation

## Test plan
- [ ] Wave 1 enemies move at the same pace as Wave 5+ enemies
- [ ] Enemies still ramp up from slow to full speed in ~1.5s after spawning
- [ ] Health, wave completion, and score scaling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)